### PR TITLE
Log out errors to stderr during piped execution

### DIFF
--- a/cmd/context_keys.go
+++ b/cmd/context_keys.go
@@ -6,5 +6,4 @@ const (
 	doerKey key = iota
 	clientKey
 	companyKey
-	stdInKey
 )

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -54,8 +54,7 @@ the token config in iris. Simply pass in any string and it will appear there.
 				//  - api_worker: Add scanned text to a list. If it gets told by ticker to upload
 				//                do that.
 
-				stdIn := ctx.Value(stdInKey).(io.Reader)
-				scanner := bufio.NewScanner(stdIn)
+				scanner := bufio.NewScanner(cmd.InOrStdin())
 
 				messages := make(chan string)
 				done := make(chan bool)

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -7,6 +7,7 @@ package cmd
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"io"
 	"time"
 
@@ -63,7 +64,7 @@ the token config in iris. Simply pass in any string and it will appear there.
 				var uploadFrequency time.Duration = 3 * time.Second
 				ticker := time.NewTicker(uploadFrequency)
 
-				go api_worker(messages, ticker.C, stop, done, ctx)
+				go api_worker(messages, ticker.C, stop, done, ctx, cmd.ErrOrStderr())
 
 				for scanner.Scan() {
 					messages <- scanner.Text()
@@ -99,9 +100,10 @@ func upload(ctx context.Context, logs []openapi.SubmitLogEvent) error {
 	return openapi.CheckStatus(resp)
 }
 
-func api_worker(messages <-chan string, control <-chan time.Time, stop <-chan bool, done chan<- bool, ctx context.Context) {
+func api_worker(messages <-chan string, control <-chan time.Time, stop <-chan bool, done chan<- bool, ctx context.Context, errOut io.Writer) {
 	logs := make([]openapi.SubmitLogEvent, 0, 1)
 	count := 0
+	var err error
 	for {
 		select {
 		case message := <-messages:
@@ -111,11 +113,17 @@ func api_worker(messages <-chan string, control <-chan time.Time, stop <-chan bo
 			})
 			count += 1
 		case <-stop:
-			upload(ctx, logs)
+			err = upload(ctx, logs)
+			if err != nil {
+				fmt.Fprintf(errOut, "%s Error: %s\n", time.Now().Format(time.RFC3339), err.Error())
+			}
 			done <- true
 			return
 		case <-control:
-			upload(ctx, logs)
+			err = upload(ctx, logs)
+			if err != nil {
+				fmt.Fprintf(errOut, "%s Error: %s\n", time.Now().Format(time.RFC3339), err.Error())
+			}
 			logs = nil
 		}
 	}

--- a/cmd/log_test.go
+++ b/cmd/log_test.go
@@ -118,10 +118,10 @@ func Test_ExecuteLog_Stdin(t *testing.T) {
 			outErr := new(bytes.Buffer)
 			rootCmd.SetOut(outStd)
 			rootCmd.SetErr(outErr)
+			rootCmd.SetIn(stdinInput)
 			rootCmd.SetArgs([]string{"log"})
 
 			ctx := context.WithValue(context.Background(), doerKey, mockDoer)
-			ctx = context.WithValue(ctx, stdInKey, stdinInput)
 			logCmd.SetContext(ctx)
 
 			err := rootCmd.ExecuteContext(ctx)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,7 +49,6 @@ var (
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute(ctx context.Context, doer openapi.HttpRequestDoer) {
 	ctx = context.WithValue(ctx, doerKey, doer)
-	ctx = context.WithValue(ctx, stdInKey, os.Stdin)
 	err := rootCmd.ExecuteContext(ctx)
 	if err != nil {
 		os.Exit(1)

--- a/pkg/openapi/utils.go
+++ b/pkg/openapi/utils.go
@@ -28,7 +28,7 @@ func CheckStatus(resp *http.Response) error {
 			if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 				return err
 			}
-			repr, err = json.MarshalIndent(*dest.Detail, "", "\t")
+			repr, err = json.Marshal(*dest.Detail)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
#1 introduced the first version of this CLI.

After discussing best behaviour following [this comment](https://github.com/syndis-software/iris-api/pull/1#discussion_r1147841021) we decided that the best way forward was that errors are logged out to stderr when in piped execution mode.

Additionally in this PR:
 - Switch to using cobra's stdin mechanism for injecting stdin in the same way as stdout/stderr, rather than using the context object